### PR TITLE
Update dataset download paths and improve code clarity in image and text classification notebooks

### DIFF
--- a/data-mining/classification/image_classification_tensorflow.ipynb
+++ b/data-mining/classification/image_classification_tensorflow.ipynb
@@ -61,7 +61,7 @@
    "outputs": [],
    "source": [
     "import pathlib\n",
-    "\n",
+    "import os\n",
     "import matplotlib.pyplot as plt\n",
     "import numpy as np\n",
     "import PIL\n",
@@ -109,10 +109,11 @@
     "data_dir = tf.keras.utils.get_file(\n",
     "    \"flower_photos.tar\",\n",
     "    origin=dataset_url,\n",
-    "    extract=True\n",
+    "    extract=True,\n",
+    "    cache_dir=\"/content/\"\n",
     ")\n",
     "\n",
-    "data_dir = pathlib.Path(data_dir).with_suffix(\"\")\n",
+    "data_dir = pathlib.Path(os.path.join(data_dir, \"flower_photos\")).with_suffix(\"\")\n",
     "print(\"Lokasi dataset:\", data_dir)"
    ]
   },
@@ -584,7 +585,7 @@
    "source": [
     "## 13. Overfitting: Apa yang Terjadi?\n",
     "\n",
-    "**Overfitting** terjadi ketika model terlalu hafal data training, tetapi kurang baik saat menghadapi data baru.\n",
+    "**Overfitting** terjadi ketika model terlalu mahir di data training, tetapi kurang baik saat menghadapi data baru.\n",
     "\n",
     "Contoh sederhana:\n",
     "\n",
@@ -672,7 +673,7 @@
    "source": [
     "## 15. Dropout\n",
     "\n",
-    "**Dropout** adalah teknik regularisasi yang mematikan sebagian unit/neuron secara acak saat training.\n",
+    "**Dropout** adalah teknik regularisasi yang menghapus sebagian unit/neuron secara acak saat training.\n",
     "\n",
     "Misalnya:\n",
     "\n",
@@ -680,7 +681,7 @@
     "layers.Dropout(0.2)\n",
     "```\n",
     "\n",
-    "Artinya, sekitar 20% unit akan dimatikan secara acak selama training.\n",
+    "Artinya, sekitar 20% unit akan dihapus secara acak selama training.\n",
     "\n",
     "Tujuannya adalah mencegah model terlalu bergantung pada neuron tertentu sehingga model belajar pola yang lebih umum."
    ]

--- a/data-mining/classification/text_classification_tensorflow.ipynb
+++ b/data-mining/classification/text_classification_tensorflow.ipynb
@@ -113,17 +113,15 @@
     "url = \"https://ai.stanford.edu/~amaas/data/sentiment/aclImdb_v1.tar.gz\"\n",
     "\n",
     "dataset_path = tf.keras.utils.get_file(\n",
-    "    fname=\"aclImdb_v1\",\n",
-    "    origin=url,\n",
+    "    \"aclImdb_v1.tar.gz\",\n",
+    "    url,\n",
     "    untar=True,\n",
-    "    cache_dir=\".\",\n",
+    "    cache_dir=\"/content/\",\n",
     "    cache_subdir=\"\"\n",
     ")\n",
     "\n",
-    "dataset_dir = os.path.join(os.path.dirname(dataset_path), \"aclImdb\")\n",
-    "\n",
-    "print(\"Lokasi dataset:\", dataset_dir)\n",
-    "print(\"Isi folder dataset:\", os.listdir(dataset_dir))"
+    "print(\"Dataset berhasil diunduh atau sudah tersedia di:\")\n",
+    "print(dataset_path)"
    ]
   },
   {
@@ -155,6 +153,34 @@
     "```\n",
     "\n",
     "Namun, di dalam `aclImdb/train` terdapat folder tambahan bernama `unsup` yang tidak memiliki label untuk klasifikasi biner. Karena itu, folder tersebut perlu dihapus agar proses pembacaan dataset menjadi bersih."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f9cfe068",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = os.path.dirname(dataset_path)\n",
+    "\n",
+    "candidate_dirs = [\n",
+    "    os.path.join(base_dir, \"aclImdb\"),\n",
+    "    os.path.join(base_dir, \"aclImdb_v1_extracted\", \"aclImdb\")\n",
+    "]\n",
+    "\n",
+    "dataset_dir = None\n",
+    "\n",
+    "for candidate in candidate_dirs:\n",
+    "    if os.path.exists(candidate):\n",
+    "        dataset_dir = candidate\n",
+    "        break\n",
+    "\n",
+    "if dataset_dir is None:\n",
+    "    raise FileNotFoundError(\"Folder aclImdb tidak ditemukan. Cek kembali proses download dan ekstraksi dataset.\")\n",
+    "\n",
+    "print(\"Folder dataset:\", dataset_dir)\n",
+    "print(\"Isi folder dataset:\", os.listdir(dataset_dir))"
    ]
   },
   {

--- a/data-prep/img-data/load_preprocess_images_tensorflow.ipynb
+++ b/data-prep/img-data/load_preprocess_images_tensorflow.ipynb
@@ -109,13 +109,14 @@
    "source": [
     "dataset_url = \"https://storage.googleapis.com/download.tensorflow.org/example_images/flower_photos.tgz\"\n",
     "\n",
-    "archive = tf.keras.utils.get_file(\n",
-    "    fname=\"flower_photos.tgz\",\n",
+    "data_dir = tf.keras.utils.get_file(\n",
+    "    \"flower_photos.tar\",\n",
     "    origin=dataset_url,\n",
-    "    extract=True\n",
+    "    extract=True,\n",
+    "    cache_dir=\"/content/\"\n",
     ")\n",
     "\n",
-    "data_dir = pathlib.Path(archive).with_suffix(\"\")\n",
+    "data_dir = pathlib.Path(os.path.join(data_dir, \"flower_photos\")).with_suffix(\"\")\n",
     "print(\"Lokasi dataset:\", data_dir)"
    ]
   },

--- a/data-prep/text-data/word_embeddings.ipynb
+++ b/data-prep/text-data/word_embeddings.ipynb
@@ -335,7 +335,7 @@
     "    \"aclImdb_v1.tar.gz\",\n",
     "    url,\n",
     "    untar=True,\n",
-    "    cache_dir=\".\",\n",
+    "    cache_dir=\"/content/\",\n",
     "    cache_subdir=\"\"\n",
     ")\n",
     "\n",


### PR DESCRIPTION
- Changed dataset cache directory to "/content/" for consistency across notebooks.
- Updated image classification notebook to use pathlib for dataset path handling.
- Improved language clarity in explanations regarding overfitting and dropout in the image classification notebook.
- Added checks for dataset directory existence in the text classification notebook to enhance robustness.